### PR TITLE
Fixes #65 : Eclipse loot adding media

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build: 
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v3
       - name: Markdown Linting Action

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -8,6 +8,7 @@ then I would encourage you to ask me or others about them or see if you need any
 - [Cool Eclipse Features](#cool-eclipse-features)
     - [Closing/Removing/Quitting](#closingremovingquitting)
     - [Debugging features review](#debugging-features-review)
+- [Cool Eclipse Keyboard shortcuts](#cool-eclipse-keyboard-shortcuts)
     - [One Final Tip](#one-final-tip)
 
 ## Cool Eclipse Features
@@ -87,11 +88,9 @@ It's smart about what parameters are required.
 
   ![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
 
-```Closing
-        > Closing Tabs and Package Explorer can help keep one's workspace clean.
-        > Not only that, but it can help with being productive with classes currently being worked on
-        > and is a way to effectively close tabs.
-  ```
+  > *Closing Tabs and Package Explorer can help keep one's workspace clean.
+  > Not only that, but it can help with being productive with classes currently being worked on
+  > and is a way to effectively close tabs.*
 
 - You can also remove the project from Eclipse,
   *right-click* the project and select *Delete*.
@@ -103,14 +102,12 @@ It's smart about what parameters are required.
   intact out in the filesystem.
   I would recommend you close instead of remove.
 
-![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
+  ![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
 
-```Removing
-        > Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through
-        > Package Explorer without scrolling to find projects, classes, etc.
-        > In addition, we recommend to ***uncheck*** the option *Delete Content From Disk*
-        > since leaving the project helps keep one's workspace clean without risking losing any progress since it stays on your computer.
-```
+  > *Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through
+  > Package Explorer without scrolling to find projects, classes, etc.
+  > In addition, we recommend to **uncheck** the option **Delete Content From Disk**
+  > since leaving the project helps keep one's workspace clean without risking losing any progress since it stays on your computer.*
 
 - When you close eclipse and open it back up it will revert back to the view you were last in.
 

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -102,9 +102,10 @@ It's smart about what parameters are required.
   
     ![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
   
-        Figure: Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through
-          Package Explorer without scrolling to find projects, classes, etc. In addition, we recommend to not "Delete Content
-          From Disk" since it helps keep one's workspace clean without the nerve of losing progress when it is located in your filesystem.
+        > Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through
+        > Package Explorer without scrolling to find projects, classes, etc.
+        > In addition, we recommend to ***uncheck*** the option *Delete Content From Disk*
+        > since leaving the project helps keep one's workspace clean without risking losing any progress since it stays on your computer.
 - When you close eclipse and open it back up it will revert back to the view you were last in.
 
 ### Debugging features review

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -85,7 +85,7 @@ It's smart about what parameters are required.
   To do this,
   *right-click* the project and select *Close*
 
-     ![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
+  ![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
 
         > Closing Tabs and Package Explorer can help keep one's workspace clean.
         > Not only that, but it can help with being productive with classes currently being worked on
@@ -100,7 +100,7 @@ It's smart about what parameters are required.
   intact out in the filesystem.
   I would recommend you close instead of remove.
 
-    ![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
+![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
   
         > Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through
         > Package Explorer without scrolling to find projects, classes, etc.

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -220,10 +220,8 @@ What's also handy though
 is adding an ```if``` statement to your code specifically to help you debug,
 something that says
 
-```java
-if (i == 67) {
-    System.out.println("reached 67th time");
-```
+    if (i == 67) {
+        System.out.println("reached 67th time");
 
 and then placing a breakpoint on that ```println``` line.
 It makes things much easier

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -221,10 +221,10 @@ well ```println``` is handy for showing a time series like that.
 What's also handy though
 is adding an ```if``` statement to your code specifically to help you debug,
 something that says
-
-    if (i == 67) {
-        System.out.println("reached 67th time");
-
+```java
+if (i == 67) {
+    System.out.println("reached 67th time");
+```
 and then placing a breakpoint on that ```println``` line.
 It makes things much easier
 when you can narrow down when something is happening.

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -223,7 +223,7 @@ is adding an ```if``` statement to your code specifically to help you debug,
 something that says
     ```java
 if (i == 67) {
-System.out.println("reached 67th time"); ```
+System.out.println("reached 67th time");```
 and then placing a breakpoint on that ```println``` line.
 It makes things much easier
 when you can narrow down when something is happening.

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -86,7 +86,7 @@ It's smart about what parameters are required.
   To do this,
   *right-click* the project and select *Close*
 
-  ![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
+  ![Animation of closing Eclipse Project](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
 
   > *Closing Tabs and Package Explorer can help keep one's workspace clean.
   > Not only that, but it can help with being productive with classes currently being worked on
@@ -102,7 +102,7 @@ It's smart about what parameters are required.
   intact out in the filesystem.
   I would recommend you close instead of remove.
 
-  ![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
+  ![Animation of deleting project](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
 
   > *Removing projects from Eclipse is a key way to keep one's workspace clean
   > and helps with navigating through

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -102,12 +102,12 @@ It's smart about what parameters are required.
   I would recommend you close instead of remove.
 
 ![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
-  
+
         > Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through
         > Package Explorer without scrolling to find projects, classes, etc.
         > In addition, we recommend to ***uncheck*** the option *Delete Content From Disk*
         > since leaving the project helps keep one's workspace clean without risking losing any progress since it stays on your computer.
-        
+
 - When you close eclipse and open it back up it will revert back to the view you were last in.
 
 ### Debugging features review

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -223,8 +223,8 @@ is adding an ```if``` statement to your code specifically to help you debug,
 something that says
 
 ```java
-    if (i == 67) {
-        System.out.println("reached 67th time");
+if (i == 67) {
+    System.out.println("reached 67th time");
 ```
 
 and then placing a breakpoint on that ```println``` line.

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -90,6 +90,7 @@ It's smart about what parameters are required.
         > Closing Tabs and Package Explorer can help keep one's workspace clean.
         > Not only that, but it can help with being productive with classes currently being worked on
         > and is a way to effectively close tabs.
+  
 - You can also remove the project from Eclipse,
   *right-click* the project and select *Delete*.
   This should prompt with a *do not delete contents*,
@@ -106,6 +107,7 @@ It's smart about what parameters are required.
         > Package Explorer without scrolling to find projects, classes, etc.
         > In addition, we recommend to ***uncheck*** the option *Delete Content From Disk*
         > since leaving the project helps keep one's workspace clean without risking losing any progress since it stays on your computer.
+        
 - When you close eclipse and open it back up it will revert back to the view you were last in.
 
 ### Debugging features review

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -85,7 +85,7 @@ It's smart about what parameters are required.
   To do this,
   *right-click* the project and select *Close*
 
-  ![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
+     ![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
 
         > Closing Tabs and Package Explorer can help keep one's workspace clean.
         > Not only that, but it can help with being productive with classes currently being worked on
@@ -100,7 +100,7 @@ It's smart about what parameters are required.
   intact out in the filesystem.
   I would recommend you close instead of remove.
 
-![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
+    ![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
   
         > Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through
         > Package Explorer without scrolling to find projects, classes, etc.
@@ -222,8 +222,8 @@ What's also handy though
 is adding an ```if``` statement to your code specifically to help you debug,
 something that says
 ```java
- if (i == 67) {
-    System.out.println("reached 67th time"); 
+if (i == 67) {
+System.out.println("reached 67th time"); 
 ```
 and then placing a breakpoint on that ```println``` line.
 It makes things much easier

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -223,8 +223,8 @@ is adding an ```if``` statement to your code specifically to help you debug,
 something that says
 
 ```java
-if (i == 67) {
-    System.out.println("reached 67th time");
+    if (i == 67) {
+        System.out.println("reached 67th time");
 ```
 
 and then placing a breakpoint on that ```println``` line.

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -222,8 +222,8 @@ What's also handy though
 is adding an ```if``` statement to your code specifically to help you debug,
 something that says
 ```java
-if (i == 67) {
-    System.out.println("reached 67th time");
+    if (i == 67) {
+        System.out.println("reached 67th time");
 ```
 and then placing a breakpoint on that ```println``` line.
 It makes things much easier

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -221,9 +221,10 @@ well ```println``` is handy for showing a time series like that.
 What's also handy though
 is adding an ```if``` statement to your code specifically to help you debug,
 something that says
-    ```java
+```java
 if (i == 67) {
-System.out.println("reached 67th time");```
+    System.out.println("reached 67th time");
+```
 and then placing a breakpoint on that ```println``` line.
 It makes things much easier
 when you can narrow down when something is happening.

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -221,10 +221,9 @@ well ```println``` is handy for showing a time series like that.
 What's also handy though
 is adding an ```if``` statement to your code specifically to help you debug,
 something that says
-```java
+    ```java
 if (i == 67) {
-System.out.println("reached 67th time"); 
-```
+System.out.println("reached 67th time"); ```
 and then placing a breakpoint on that ```println``` line.
 It makes things much easier
 when you can narrow down when something is happening.

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -221,10 +221,10 @@ well ```println``` is handy for showing a time series like that.
 What's also handy though
 is adding an ```if``` statement to your code specifically to help you debug,
 something that says
-```java
+    ```java
     if (i == 67) {
         System.out.println("reached 67th time");
-```
+    ```
 and then placing a breakpoint on that ```println``` line.
 It makes things much easier
 when you can narrow down when something is happening.

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -85,11 +85,10 @@ It's smart about what parameters are required.
   To do this,
   *right-click* the project and select *Close*
   
-![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
-    
-    Figure: Closing Tabs and Package Explorer can help keep one's workspace clean. Not only that, but it can help
-      with being productive with classes currently being worked on and is a way to effectively close tabs.
-  
+    ![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
+
+        Figure: Closing Tabs and Package Explorer can help keep one's workspace clean. Not only that, but it can help
+           with being productive with classes currently being worked on and is a way to effectively close tabs.
 - You can also remove the project from Eclipse,
   *right-click* the project and select *Delete*.
   This should prompt with a *do not delete contents*,
@@ -100,12 +99,11 @@ It's smart about what parameters are required.
   intact out in the filesystem.
   I would recommend you close instead of remove.
   
-![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
-
-    Figure: Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through Package Explorer without scrolling to find
-      projects, classes, etc. In addition, we recommend to not "Delete Content From Disk" since it helps keep one's workspace clean without the nerve of losing progress
-      when it is located in your filesystem.
-
+    ![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
+  
+        Figure: Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through
+          Package Explorer without scrolling to find projects, classes, etc. In addition, we recommend to not "Delete Content
+          From Disk" since it helps keep one's workspace clean without the nerve of losing progress when it is located in your filesystem.
 - When you close eclipse and open it back up it will revert back to the view you were last in.
 
 ### Debugging features review

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -221,10 +221,12 @@ well ```println``` is handy for showing a time series like that.
 What's also handy though
 is adding an ```if``` statement to your code specifically to help you debug,
 something that says
+
 ```java
 if (i == 67) {
     System.out.println("reached 67th time");
 ```
+
 and then placing a breakpoint on that ```println``` line.
 It makes things much easier
 when you can narrow down when something is happening.

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -104,10 +104,12 @@ It's smart about what parameters are required.
 
   ![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
 
-  > *Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through
+  > *Removing projects from Eclipse is a key way to keep one's workspace clean
+  > and helps with navigating through
   > Package Explorer without scrolling to find projects, classes, etc.
   > In addition, we recommend to **uncheck** the option **Delete Content From Disk**
-  > since leaving the project helps keep one's workspace clean without risking losing any progress since it stays on your computer.*
+  > since leaving the project helps keep one's workspace clean
+  > without risking losing any progress since it stays on your computer.*
 
 - When you close eclipse and open it back up it will revert back to the view you were last in.
 

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -84,8 +84,8 @@ It's smart about what parameters are required.
   which some people prefer to make it faster.
   To do this,
   *right-click* the project and select *Close*
-  
-    ![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
+
+  ![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
 
         > Closing Tabs and Package Explorer can help keep one's workspace clean.
         > Not only that, but it can help with being productive with classes currently being worked on
@@ -99,8 +99,8 @@ It's smart about what parameters are required.
   but leaves its directory, files, etc.
   intact out in the filesystem.
   I would recommend you close instead of remove.
-  
-    ![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
+
+![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
   
         > Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through
         > Package Explorer without scrolling to find projects, classes, etc.
@@ -221,9 +221,10 @@ well ```println``` is handy for showing a time series like that.
 What's also handy though
 is adding an ```if``` statement to your code specifically to help you debug,
 something that says
-    ```java
-    if (i == 67) {
-        System.out.println("reached 67th time"); ```
+```java
+ if (i == 67) {
+    System.out.println("reached 67th time"); 
+```
 and then placing a breakpoint on that ```println``` line.
 It makes things much easier
 when you can narrow down when something is happening.

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -87,8 +87,9 @@ It's smart about what parameters are required.
   
     ![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
 
-        Figure: Closing Tabs and Package Explorer can help keep one's workspace clean. Not only that, but it can help
-           with being productive with classes currently being worked on and is a way to effectively close tabs.
+        > Closing Tabs and Package Explorer can help keep one's workspace clean.
+        > Not only that, but it can help with being productive with classes currently being worked on
+        > and is a way to effectively close tabs.
 - You can also remove the project from Eclipse,
   *right-click* the project and select *Delete*.
   This should prompt with a *do not delete contents*,

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -87,10 +87,12 @@ It's smart about what parameters are required.
 
   ![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
 
+```Closing
         > Closing Tabs and Package Explorer can help keep one's workspace clean.
         > Not only that, but it can help with being productive with classes currently being worked on
         > and is a way to effectively close tabs.
-  
+  ```
+
 - You can also remove the project from Eclipse,
   *right-click* the project and select *Delete*.
   This should prompt with a *do not delete contents*,
@@ -103,10 +105,12 @@ It's smart about what parameters are required.
 
 ![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
 
+```Removing
         > Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through
         > Package Explorer without scrolling to find projects, classes, etc.
         > In addition, we recommend to ***uncheck*** the option *Delete Content From Disk*
         > since leaving the project helps keep one's workspace clean without risking losing any progress since it stays on your computer.
+```
 
 - When you close eclipse and open it back up it will revert back to the view you were last in.
 

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -223,8 +223,7 @@ is adding an ```if``` statement to your code specifically to help you debug,
 something that says
     ```java
     if (i == 67) {
-        System.out.println("reached 67th time");
-    ```
+        System.out.println("reached 67th time"); ```
 and then placing a breakpoint on that ```println``` line.
 It makes things much easier
 when you can narrow down when something is happening.

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -84,7 +84,9 @@ It's smart about what parameters are required.
   which some people prefer to make it faster.
   To do this,
   *right-click* the project and select *Close*
+  
 ![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
+    
     Figure: Closing Tabs and Package Explorer can help keep one's workspace clean. Not only that, but it can help
       with being productive with classes currently being worked on and is a way to effectively close tabs.
   
@@ -97,7 +99,9 @@ It's smart about what parameters are required.
   but leaves its directory, files, etc.
   intact out in the filesystem.
   I would recommend you close instead of remove.
+  
 ![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
+
     Figure: Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through Package Explorer without scrolling to find
       projects, classes, etc. In addition, we recommend to not "Delete Content From Disk" since it helps keep one's workspace clean without the nerve of losing progress
       when it is located in your filesystem.

--- a/docs/labs/EclipseLoot.md
+++ b/docs/labs/EclipseLoot.md
@@ -84,7 +84,10 @@ It's smart about what parameters are required.
   which some people prefer to make it faster.
   To do this,
   *right-click* the project and select *Close*
-
+![Closing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/7b00a40e-a86f-40e1-bcec-4bcb9fa9e8dc)
+    Figure: Closing Tabs and Package Explorer can help keep one's workspace clean. Not only that, but it can help
+      with being productive with classes currently being worked on and is a way to effectively close tabs.
+  
 - You can also remove the project from Eclipse,
   *right-click* the project and select *Delete*.
   This should prompt with a *do not delete contents*,
@@ -94,6 +97,10 @@ It's smart about what parameters are required.
   but leaves its directory, files, etc.
   intact out in the filesystem.
   I would recommend you close instead of remove.
+![Removing_EclipseLoot](https://github.com/comp129/comp55/assets/148159945/1848723a-3e5e-4e42-9fe9-4e14ded1e3fe)
+    Figure: Removing projects from Eclipse is a key way to keep one's workspace clean and helps with navigating through Package Explorer without scrolling to find
+      projects, classes, etc. In addition, we recommend to not "Delete Content From Disk" since it helps keep one's workspace clean without the nerve of losing progress
+      when it is located in your filesystem.
 
 - When you close eclipse and open it back up it will revert back to the view you were last in.
 


### PR DESCRIPTION
Fixes #65 Includes Changes For Closing/Removing/Quitting section in EclipseLoot. The changes are an addition of two gifs to illustrate how a user can Close and Remove Eclipse to help with one's experience navigating Eclipse. A brief description was also added for each gif to advise one on how these tools can help in being efficient and productive while using Eclipse IDE.