### PR TITLE
Fixes #66: GitTips missing visual

### DIFF
--- a/docs/labs/GitTips.md
+++ b/docs/labs/GitTips.md
@@ -81,14 +81,15 @@ use you.
     If it won't let you, continue the pull and merge.
 
     Here is what a conflicting merge looks like:
-   
+
     ![Egit-0 10-merge-conflict](https://github.com/comp129/comp55/assets/76021136/2ffb97bc-4b48-4e98-a12d-9afdac298a02)
 
-   When there are conflicting merges, this means that you'll have to choose between your changes or the changes from the branch you're merging with.
+   When there are conflicting merges, this means that you'll have to choose between
+   your changes or the changes from the branch you're merging with.
    Make sure you're selecting one set of changes instead of combining both changes.
-    To get a better understanding of this, you can go to step 8 in [here](https://github.com/comp129/comp55/blob/main/docs/labs/9-Github.md).
+   To get a better understanding of this, you can go to step 8 in [here](https://github.com/comp129/comp55/blob/main/docs/labs/9-Github.md).
 
-6. If you're having issues with the repository,
+5. If you're having issues with the repository,
    you can always reset your folder to match the latest version.
    To do this,
    right-click on the project,

--- a/docs/labs/GitTips.md
+++ b/docs/labs/GitTips.md
@@ -87,7 +87,7 @@ use you.
    When there are conflicting merges, this means that you'll have to choose between
    your changes or the changes from the branch you're merging with.
    Typically, you'll select one set of changes but on occasion you may need to select changes from both.
-   To get a better understanding of this, you can go to step 8 in [here](https://github.com/comp129/comp55/blob/main/docs/labs/9-Github.md).
+   To get a better understanding of this, you can go to [step 8 of the GitHub Lab](9-Github.html#step-8-martyr--hackslash---commit-and-push-the-same-line).
 
 5. If you're having issues with the repository,
    you can always reset your folder to match the latest version.

--- a/docs/labs/GitTips.md
+++ b/docs/labs/GitTips.md
@@ -85,7 +85,7 @@ use you.
     ![Egit-0 10-merge-conflict](https://github.com/comp129/comp55/assets/76021136/2ffb97bc-4b48-4e98-a12d-9afdac298a02)
 
     You will have to coordinate with your team which lines to keep and which lines to delete.
-    You will also have to remove the  "<<<<< HEAD", "======", and ">>>>>>".
+    You will also have to remove the  `<<<<< HEAD`, `======`, and `>>>>>>`.
     These markers delineate the conflicting changes.
     After you have done that, you can successfully push the code.
 

--- a/docs/labs/GitTips.md
+++ b/docs/labs/GitTips.md
@@ -86,7 +86,7 @@ use you.
 
    When there are conflicting merges, this means that you'll have to choose between
    your changes or the changes from the branch you're merging with.
-   Make sure you're selecting one set of changes instead of combining both changes.
+   Typically, you'll select one set of changes but on occasion you may need to select changes from both.
    To get a better understanding of this, you can go to step 8 in [here](https://github.com/comp129/comp55/blob/main/docs/labs/9-Github.md).
 
 5. If you're having issues with the repository,

--- a/docs/labs/GitTips.md
+++ b/docs/labs/GitTips.md
@@ -84,12 +84,12 @@ use you.
 
     ![Egit-0 10-merge-conflict](https://github.com/comp129/comp55/assets/76021136/2ffb97bc-4b48-4e98-a12d-9afdac298a02)
 
-    You will have to coordinate with your team which lines to keep and which lines to delete.
-    You will also have to remove the  `<<<<< HEAD`, `======`, and `>>>>>>`.
-    These markers delineate the conflicting changes.
-    After you have done that, you can successfully push the code.
+    When there are conflicting merges, this means that you'll have to choose between your changes or the changes from the branch you're merging with.
+   Make sure you're selecting one set of changes instead of combining both changes.
+    To get a better understanding of this, you can go to step 8 in [here](https://github.com/comp129/comp55/blob/main/docs/labs/9-Github.md).
+    
 
-5. If you're having issues with the repository,
+6. If you're having issues with the repository,
    you can always reset your folder to match the latest version.
    To do this,
    right-click on the project,

--- a/docs/labs/GitTips.md
+++ b/docs/labs/GitTips.md
@@ -81,13 +81,12 @@ use you.
     If it won't let you, continue the pull and merge.
 
     Here is what a conflicting merge looks like:
-
+   
     ![Egit-0 10-merge-conflict](https://github.com/comp129/comp55/assets/76021136/2ffb97bc-4b48-4e98-a12d-9afdac298a02)
 
-    When there are conflicting merges, this means that you'll have to choose between your changes or the changes from the branch you're merging with.
+   When there are conflicting merges, this means that you'll have to choose between your changes or the changes from the branch you're merging with.
    Make sure you're selecting one set of changes instead of combining both changes.
     To get a better understanding of this, you can go to step 8 in [here](https://github.com/comp129/comp55/blob/main/docs/labs/9-Github.md).
-    
 
 6. If you're having issues with the repository,
    you can always reset your folder to match the latest version.

--- a/docs/labs/GitTips.md
+++ b/docs/labs/GitTips.md
@@ -82,7 +82,6 @@ use you.
 
     Here is what a conflicting merge looks like:
 
-   
     ![Egit-0 10-merge-conflict](https://github.com/comp129/comp55/assets/76021136/2ffb97bc-4b48-4e98-a12d-9afdac298a02)
 
     You will have to coordinate with your team which lines to keep and which lines to delete.
@@ -91,7 +90,7 @@ use you.
     After you have done that, you can successfully push the code.
 
 
-6. If you're having issues with the repository,
+5. If you're having issues with the repository,
    you can always reset your folder to match the latest version.
    To do this,
    right-click on the project,

--- a/docs/labs/GitTips.md
+++ b/docs/labs/GitTips.md
@@ -89,7 +89,6 @@ use you.
     These markers delineate the conflicting changes.
     After you have done that, you can successfully push the code.
 
-
 5. If you're having issues with the repository,
    you can always reset your folder to match the latest version.
    To do this,

--- a/docs/labs/GitTips.md
+++ b/docs/labs/GitTips.md
@@ -80,7 +80,18 @@ use you.
     (You can just use the option "push upstream".
     If it won't let you, continue the pull and merge.
 
-5. If you're having issues with the repository,
+    Here is what a conflicting merge looks like:
+
+   
+    ![Egit-0 10-merge-conflict](https://github.com/comp129/comp55/assets/76021136/2ffb97bc-4b48-4e98-a12d-9afdac298a02)
+
+    You will have to coordinate with your team which lines to keep and which lines to delete.
+    You will also have to remove the  "<<<<< HEAD", "======", and ">>>>>>".
+    These markers delineate the conflicting changes.
+    After you have done that, you can successfully push the code.
+
+
+6. If you're having issues with the repository,
    you can always reset your folder to match the latest version.
    To do this,
    right-click on the project,


### PR DESCRIPTION
Fixes #66 . Includes a visual representation of conflicting merges as well as a small description of what the markers indicate and what the user has to do in order to resolve the conflict. 